### PR TITLE
Fix arbitrary config reordering on launch

### DIFF
--- a/src/main/java/fathertoast/crust/api/config/common/value/RegistryEntryList.java
+++ b/src/main/java/fathertoast/crust/api/config/common/value/RegistryEntryList.java
@@ -25,7 +25,7 @@ public class RegistryEntryList<T> implements IStringArray {
     private final IForgeRegistry<T> REGISTRY;
     
     /** The entries in this list. */
-    protected final Set<T> UNDERLYING_SET = new HashSet<>();
+    protected final Set<T> UNDERLYING_SET = new LinkedHashSet<>();
     /** The tags in this list. */
     private final List<TagKey<T>> TAGS = new ArrayList<>();
     /** Entire namespaces specified in this list. */


### PR DESCRIPTION
Configs that use RegistryEntryList currently have the default value config comment rewritten when the game launches since HashSet uses an arbitrary order instead of insertion order. This means every launch, the comment in the config has a chance to be reordered, causing unnecessary updates to the config files without changing anything.

In practice, this is seen because the comment above the general.special_data.immune_to_effects config for undead mobs would be regenerated on launch, swapping between:
```
  # <"minecraft:mob_effect" Registry List> Format: [ "namespace:entry_name", ... ], Default: [
  #   "minecraft:regeneration", "minecraft:poison" ]
```
and 
```
  # <"minecraft:mob_effect" Registry List> Format: [ "namespace:entry_name", ... ], Default: [ "minecraft:poison",
  #   "minecraft:regeneration" ]
```

This is very inconvenient when using version control systems for modpack configs since these files frequently changed on launch and I had to manually discard the changes after most game launches. Switching to a LinkedHashSet ensures they are kept in the same order they are added in and that they don't change upon launch anymore.